### PR TITLE
Fix mount of configuration file for ecommer-worker in k8s deployment.

### DIFF
--- a/tutorecommerce/patches/k8s-deployments
+++ b/tutorecommerce/patches/k8s-deployments
@@ -57,7 +57,7 @@ spec:
             - name: C_FORCE_ROOT
               value: "1"
           volumeMounts:
-            - mountPath: /openedx/ecommerce_worker/ecommerce_worker/configuration/tutor_worker.py:ro
+            - mountPath: /openedx/ecommerce_worker/ecommerce_worker/configuration/tutor_worker.py
               name: settings
               subPath: tutor_worker.py
       volumes:


### PR DESCRIPTION
'ro' is not needed for mounting k8s configMap.