### PR TITLE
Set ENTERPRISE_SERVICE_URL to the LMS host address

### DIFF
--- a/tutorecommerce/templates/ecommerce/apps/tutor.py
+++ b/tutorecommerce/templates/ecommerce/apps/tutor.py
@@ -71,6 +71,9 @@ EMAIL_HOST_USER = "{{ SMTP_USERNAME }}"
 EMAIL_HOST_PASSWORD = "{{ SMTP_PASSWORD }}"
 EMAIL_USE_TLS = {{SMTP_USE_TLS}}
 
+ENTERPRISE_SERVICE_URL = '{% if ACTIVATE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/enterprise/'
+ENTERPRISE_API_URL = urljoin(ENTERPRISE_SERVICE_URL, 'api/v1/')
+
 LOGGING["handlers"]["local"] = {
     "class": "logging.handlers.WatchedFileHandler",
     "filename": "/var/log/ecommerce.log",


### PR DESCRIPTION
Fixes https://github.com/overhangio/tutor-ecommerce/issues/10

Note that as mentioned in the issue, `ENTERPRISE_API_URL` must be re-set too to ensure the correct value is set, due to the way the ecommerce module nests the setting imports.