### PR TITLE
feat: open stdin & allocate tty on dev services

### DIFF
--- a/tutorecommerce/patches/local-docker-compose-dev-services
+++ b/tutorecommerce/patches/local-docker-compose-dev-services
@@ -4,6 +4,8 @@ ecommerce:
   command: ./manage.py runserver 0.0.0.0:8130
   ports:
     - "127.0.0.1:8130:8130"
+  stdin_open: true
+  tty: true
   volumes:
     # editable requirements
     - ../plugins/ecommerce/build/ecommerce/requirements:/openedx/requirements


### PR DESCRIPTION
This ensures that services started with `tutor dev start`
are as capable for breakpoint debugging, et al, as services
started with `tutor dev runserver` are. We plan to remove
`tutor dev runserver`.

Blocks https://github.com/overhangio/tutor/pull/644