### PR TITLE
fix: cors issue in payment page in dev

### DIFF
--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/development.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/development.py
@@ -4,6 +4,7 @@ from ..devstack import *
 
 CORS_ORIGIN_WHITELIST = list(CORS_ORIGIN_WHITELIST) + [
     "http://{{ MFE_HOST }}:{{ ECOMMERCE_MFE_APP['port'] }}",
+    "http://{{ MFE_HOST }}:{{ PAYMENT_MFE_APP['port'] }}",
 ]
 CSRF_TRUSTED_ORIGINS = ["{{ MFE_HOST }}:{{ ECOMMERCE_MFE_APP['port'] }}"]
 

--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/development.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/development.py
@@ -11,3 +11,5 @@ CSRF_TRUSTED_ORIGINS = ["{{ MFE_HOST }}:{{ ECOMMERCE_MFE_APP['port'] }}"]
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "http://{{ LMS_HOST }}:8000"
 
 BACKEND_SERVICE_EDX_OAUTH2_KEY = "{{ ECOMMERCE_OAUTH2_KEY_DEV }}"
+
+{{ patch("ecommerce-settings-development") }}

--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/partials/common.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/partials/common.py
@@ -87,3 +87,5 @@ PAYMENT_PROCESSORS = list(PAYMENT_PROCESSORS) + {{ ECOMMERCE_EXTRA_PAYMENT_PROCE
 {% for payment_processor, urls_module in ECOMMERCE_EXTRA_PAYMENT_PROCESSOR_URLS.items() %}
 EXTRA_PAYMENT_PROCESSOR_URLS["{{ payment_processor }}"] = "{{ urls_module }}"
 {% endfor %}
+
+{{ patch("ecommerce-settings-common") }}

--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/production.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/production.py
@@ -10,3 +10,5 @@ CSRF_TRUSTED_ORIGINS = ["{{ MFE_HOST }}"]
 SOCIAL_AUTH_EDX_OAUTH2_PUBLIC_URL_ROOT = "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}"
 
 BACKEND_SERVICE_EDX_OAUTH2_KEY = "{{ ECOMMERCE_OAUTH2_KEY }}"
+
+{{ patch("ecommerce-settings-production") }}


### PR DESCRIPTION
The payment page in dev makes a call to ecommerce, which was blocked byCORS.

In this PR, we also add a couple patch statements to make it easier for people running lilac to backport fixes from maple.