### PR TITLE
docs: replace `runserver` with `start`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -140,7 +140,7 @@ You will have to generate static assets in your local repository::
 
 To attach a debugger to the ecommerce service, run::
 
-    tutor dev runserver ecommerce
+    tutor dev start ecommerce
 
 Funding
 -------


### PR DESCRIPTION
Part of https://github.com/overhangio/2u-tutor-adoption/issues/26

In order to remove `runserver`, the following must be done for all official tutor plugins:

- [X] Ensure that the plugin is ported to the V1 API
- [X] Ensure that the plugin hooks into the COMPOSE_MOUNTS filter in order to automatically bind-mount folders as appropriate.
- [x] Replace any references to runserver with start
- [X] Replace any references to the --volume option with an equivalent usage of the --mount option.

Within this repo, there was only one incomplete task: 'Replace any references to `runserver` with `start`'. This task is solved with this PR.