### PR TITLE
fix: support multi-line values in payment processors

### DIFF
--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/partials/common.py
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/partials/common.py
@@ -1,4 +1,5 @@
 import json
+import os
 
 SECRET_KEY = "{{ ECOMMERCE_SECRET_KEY }}"
 ALLOWED_HOSTS = [
@@ -77,7 +78,13 @@ LOGGING["handlers"].pop("local")
 for logger in LOGGING["loggers"].values():
     logger["handlers"].remove("local")
 
-common_payment_processor_config = json.loads("""{{ ECOMMERCE_PAYMENT_PROCESSORS|tojson(indent=4) }}""")
+# Load payment processors
+with open(
+    os.path.join(os.path.dirname(__file__), "paymentprocessors.json"),
+    encoding="utf8"
+) as payment_processors_file:
+    common_payment_processor_config = json.load(payment_processors_file)
+
 # Fix cybersource-rest configuration
 if "cybersource" in common_payment_processor_config and "cybersource-rest" not in common_payment_processor_config:
     common_payment_processor_config["cybersource-rest"] = common_payment_processor_config["cybersource"]

--- a/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/paymentprocessors.json
+++ b/tutorecommerce/templates/ecommerce/apps/ecommerce/settings/paymentprocessors.json
@@ -1,0 +1,1 @@
+{{ ECOMMERCE_PAYMENT_PROCESSORS|tojson(indent=4) }}


### PR DESCRIPTION
By dumping the payment processors to a separate json file, we make sure that there are no weird character conversion when dumping to python.

Close #32.