### PR TITLE
feat: add patch ecommerce-dockerfile-pre-assets

### DIFF
--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -46,6 +46,10 @@ RUN cd /openedx/requirements/ \
 {% for extra_requirement in ECOMMERCE_EXTRA_PIP_REQUIREMENTS %}RUN pip install {{ extra_requirement }}
 {% endfor %}
 
+{%- if patch("ecommerce-dockerfile-pre-assets") %}
+{{ patch("ecommerce-dockerfile-pre-assets") }}
+{%- endif %}
+
 # Collect static assets (aka: "make static")
 COPY --chown=app:app assets.py ./ecommerce/settings/assets.py
 ENV DJANGO_SETTINGS_MODULE ecommerce.settings.assets


### PR DESCRIPTION
Add a patch `ecommerce-dockerfile-pre-assets` that allows to add new commands on ecommerce Dockerfile before running the collect static assets.
The name of the patch was inspired by the tutor `openedx-dockerfile-pre-assets` patch.
https://github.com/fccn/tutor/blob/74ef1ae56e9bbd4c6a9441a10bb90576136243be/tutor/templates/build/openedx/Dockerfile/#L193

This new patch allows, for example, to add a custom theme to the ecommerce.

```
ecommerce-dockerfile-pre-assets: |
    COPY --chown=app:app ./themes/ /openedx/ecommerce/ecommerce/themes/
```
