### PR TITLE
feat: add patch ecommerce-dockerfile-pre-assets

### DIFF
--- a/changelog.d/20231123_114642_ivo.branco.md
+++ b/changelog.d/20231123_114642_ivo.branco.md
@@ -1,0 +1,1 @@
+- [Feature] Add patch ecommerce-dockerfile-pre-assets. (by @igobranco)

--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -79,6 +79,8 @@ RUN cd /openedx/requirements/ \
 {% for extra_requirement in ECOMMERCE_EXTRA_PIP_REQUIREMENTS %}RUN {% if is_buildkit_enabled() %}--mount=type=cache,target=/openedx/.cache/pip,sharing=shared,uid=${APP_USER_ID} {% endif %}pip install '{{ extra_requirement }}'
 {% endfor %}
 
+{{ patch("ecommerce-dockerfile-pre-assets") }}
+
 # Collect static assets (aka: "make static")
 COPY --chown=app:app assets.py ./ecommerce/settings/assets.py
 ENV DJANGO_SETTINGS_MODULE ecommerce.settings.assets


### PR DESCRIPTION
Add a patch `ecommerce-dockerfile-pre-assets` that allows to add new commands on ecommerce Dockerfile before running the collect static assets.
The name of the patch was inspired by the tutor `openedx-dockerfile-pre-assets` patch.
https://github.com/fccn/tutor/blob/74ef1ae56e9bbd4c6a9441a10bb90576136243be/tutor/templates/build/openedx/Dockerfile/#L193

This new patch allows, for example, to add a custom theme to the ecommerce.

```
ecommerce-dockerfile-pre-assets: |
    COPY --chown=app:app ./themes/ /openedx/ecommerce/ecommerce/themes/
```
