### PR TITLE
fix: double quotes added around CONTACT_EMAIL

### DIFF
--- a/tutorecommerce/templates/ecommerce/tasks/ecommerce/init
+++ b/tutorecommerce/templates/ecommerce/tasks/ecommerce/init
@@ -14,8 +14,8 @@
   --sso-client-secret="{{ ECOMMERCE_OAUTH2_SECRET_SSO }}" \
   --backend-service-client-id="{{ ECOMMERCE_OAUTH2_KEY_DEV }}" \
   --backend-service-client-secret="{{ ECOMMERCE_OAUTH2_SECRET }}" \
-  --from-email={{ CONTACT_EMAIL }} \
-  --payment-support-email={{ CONTACT_EMAIL }} \
+  --from-email="{{ CONTACT_EMAIL }}" \
+  --payment-support-email="{{ CONTACT_EMAIL }}" \
   --payment-support-url="http://{{ LMS_HOST }}:8000/support" \
   --discovery_api_url=http://{{ DISCOVERY_HOST }}:8381/api/v1/ \
   --enable-microfrontend-for-basket-page=true \
@@ -36,8 +36,8 @@
   --sso-client-secret="{{ ECOMMERCE_OAUTH2_SECRET_SSO }}" \
   --backend-service-client-id="{{ ECOMMERCE_OAUTH2_KEY }}" \
   --backend-service-client-secret="{{ ECOMMERCE_OAUTH2_SECRET }}" \
-  --from-email={{ CONTACT_EMAIL }} \
-  --payment-support-email={{ CONTACT_EMAIL }} \
+  --from-email="{{ CONTACT_EMAIL }}" \
+  --payment-support-email="{{ CONTACT_EMAIL }}" \
   --payment-support-url="{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ LMS_HOST }}/support" \
   --discovery_api_url={% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ DISCOVERY_HOST }}/api/v1/ \
   --enable-microfrontend-for-basket-page=true \


### PR DESCRIPTION
As mentioned in #51, when users have a CONTACT_EMAIL like My LMS <no-reply@example.com>, the init task will fail simply because it contains whitespace and it's not a string.

Close #51