### PR TITLE
docs: add flex-run-enviornment configuration value change for cyberso…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ To enable the `Cybersource <https://cybersource.com>`__ payment processor, two k
 
 The ``merchant_id`` setting corresponds to your Merchant ID.
 
-If you are running in production, you need to change the ``flex-run-environment`` value in the configuration file as well. You should change the ``flex-run-environment`` value to ``cybersource.environment.production``
+If you are running in production, you need to change the ``flex_run_environment`` value in the configuration file as well. You should change the ``flex_run_environment`` value to ``cybersource.environment.production``
 
 Operations
 ----------

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ You will need to modify the ``ECOMMERCE_PAYMENT_PROCESSORS`` parameter to config
         flex_shared_secret_key: SET-ME-PLEASE
         soap_api_url: https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.140.wsdl
         transaction_key: SET-ME-PLEASE
-        flex-run-environment: cybersource.environment.sandbox
+        flex_run_environment: cybersource.environment.sandbox
       paypal:
         cancel_checkout_path: /checkout/cancel-checkout/
         client_id: SET-ME-PLEASE

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,7 @@ You will need to modify the ``ECOMMERCE_PAYMENT_PROCESSORS`` parameter to config
         flex_shared_secret_key: SET-ME-PLEASE
         soap_api_url: https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.140.wsdl
         transaction_key: SET-ME-PLEASE
+        flex-run-environment: cybersource.environment.sandbox
       paypal:
         cancel_checkout_path: /checkout/cancel-checkout/
         client_id: SET-ME-PLEASE
@@ -80,6 +81,8 @@ To enable the `Cybersource <https://cybersource.com>`__ payment processor, two k
 - REST Shared secret: use the key ID and value to define ``flex_shared_secret_key_id`` and ``flex_shared_secret_key``, respectively.
 
 The ``merchant_id`` setting corresponds to your Merchant ID.
+
+If you are running in production, you need to change the ``flex-run-environment`` value in the configuration file as well. You should change the ``flex-run-environment`` value to ``cybersource.environment.production``
 
 Operations
 ----------

--- a/changelog.d/20240122_160838_danyal.faheem_add_configuration_step_in_docs.md
+++ b/changelog.d/20240122_160838_danyal.faheem_add_configuration_step_in_docs.md
@@ -1,0 +1,1 @@
+[Improvement] Added flex_run_environment setting variable for cybersource payment. Updated docs for it as well. (by @Danyal-Faheem)

--- a/tutorecommerce/plugin.py
+++ b/tutorecommerce/plugin.py
@@ -45,7 +45,7 @@ config = {
                 "merchant_id": "SET-ME-PLEASE",
                 "soap_api_url": "https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.140.wsdl",
                 "transaction_key": "SET-ME-PLEASE",
-                "flex-run-environment": "cybersource.environment.sandbox",
+                "flex_run_environment": "cybersource.environment.sandbox",
             },
             "paypal": {
                 "mode": "sandbox",

--- a/tutorecommerce/plugin.py
+++ b/tutorecommerce/plugin.py
@@ -45,6 +45,7 @@ config = {
                 "merchant_id": "SET-ME-PLEASE",
                 "soap_api_url": "https://ics2wstest.ic3.com/commerce/1.x/transactionProcessor/CyberSourceTransaction_1.140.wsdl",
                 "transaction_key": "SET-ME-PLEASE",
+                "flex-run-environment": "cybersource.environment.sandbox",
             },
             "paypal": {
                 "mode": "sandbox",


### PR DESCRIPTION
Fixes #29.

**Changes**

- Update docs to include the `flex-run-environment` variable in `Cybersource` payment processor.
- Added small note to change the value of `flex-run-environment` when running in production.