### PR TITLE
fix: typo in change log

### DIFF
--- a/changelog.d/20240125_122858_shadinaif_FC_0012_OEP_58.md
+++ b/changelog.d/20240125_122858_shadinaif_FC_0012_OEP_58.md
@@ -1,1 +1,1 @@
-💥[Feature] Add support to `atlas pull` - FC-0012 project, OEP-58. (by @shadinaif) -->
+- [Feature] Add support to `atlas pull` - FC-0012 project, OEP-58. (by @shadinaif)


### PR DESCRIPTION
fix: typo in change log

Typo introduced in https://github.com/overhangio/tutor-ecommerce/pull/49