### PR TITLE
Add mounts for docker-compose-dev-services

### DIFF
--- a/changelog.d/20240220_181216_cmltawt0_mounts.md
+++ b/changelog.d/20240220_181216_cmltawt0_mounts.md
@@ -1,0 +1,1 @@
+- [Feature] Make it possible to use mounts for a local development. (by @cmltawt0)

--- a/tutorecommerce/patches/local-docker-compose-dev-services
+++ b/tutorecommerce/patches/local-docker-compose-dev-services
@@ -9,6 +9,9 @@ ecommerce:
   volumes:
     # editable requirements
     - ../plugins/ecommerce/build/ecommerce/requirements:/openedx/requirements
+    {%- for mount in iter_mounts(MOUNTS, "ecommerce") %}
+    - {{ mount }}
+    {%- endfor %}
   networks:
     default:
       aliases:


### PR DESCRIPTION
This PR is adding the ability to do a local development for ecommerce.

How to test:

```
tutor mounts add ./src/ecommerce
cat root/env/dev/docker-compose.yml
tutor dev start -d ecommerce
```