### PR TITLE
ci: add python 3.12 in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,12 +7,15 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+         python-version: ['3.8', '3.12']
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up Python 3.8
-        uses: actions/setup-python@v2
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version:  ${{ matrix.python-version }}
       - name: Upgrade pip
         run: python -m pip install --upgrade pip setuptools
       - name: Install dependencies

--- a/changelog.d/20240313_150658_danyal.faheem_upgrade_to_python_3_12.md
+++ b/changelog.d/20240313_150658_danyal.faheem_upgrade_to_python_3_12.md
@@ -1,0 +1,1 @@
+- [Feature] Add Python 3.12 CI checks (by @Danyal-Faheem)


### PR DESCRIPTION
The plugin was already compatible with Python 3.12 after this [commit](https://github.com/overhangio/tutor-ecommerce/commit/62c4f79c6792aea4b6f4ffd7ab897a1c2bbe9cc5).

I have just updated the workflows for both python 3.8 and python 3.12 as mentioned [here](https://github.com/overhangio/cookiecutter-tutor-plugin/issues/30#issuecomment-1966466502)

However, the dockerfile is still to be updated for python 3.12.