### PR TITLE
ci: add python 3.11 checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-         python-version: ['3.8', '3.12']
+         python-version: ['3.8', '3.11', '3.12']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python


### PR DESCRIPTION
Added python 3.11 checks in the ci as well. Tested this workflow locally and the job was successfull.