### PR TITLE
fix: point ecommerce/ecommerce-worker giturls to openedx github org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,7 @@
 E-Commerce plugin for `Tutor <https://docs.tutor.edly.io>`_
 ===============================================================
 
-This is a plugin for `Tutor <https://docs.tutor.edly.io>`_ that integrates the `E-Commerce <https://github.com/edx/ecommerce/>`__ application in an Open edX platform.
+This is a plugin for `Tutor <https://docs.tutor.edly.io>`_ that integrates the `E-Commerce <https://github.com/openedx/ecommerce/>`__ application in an Open edX platform.
 
 Installation
 ------------

--- a/changelog.d/20240417_144650_cpappas_update_more_ecommerce_git_urls.md
+++ b/changelog.d/20240417_144650_cpappas_update_more_ecommerce_git_urls.md
@@ -1,0 +1,1 @@
+- [Improvement] Change ecommerce and ecommerce-worker remotes from `edx` to `openedx`. (by @christopappas)

--- a/tutorecommerce/templates/ecommerce/build/ecommerce-worker/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce-worker/Dockerfile
@@ -12,7 +12,7 @@ RUN useradd --home-dir /openedx --create-home --shell /bin/bash --uid ${APP_USER
 USER ${APP_USER_ID}
 
 RUN mkdir /openedx/ecommerce_worker && \
-    git clone https://github.com/edx/ecommerce-worker.git --branch {{ OPENEDX_COMMON_VERSION }} --depth 1 /openedx/ecommerce_worker
+    git clone https://github.com/openedx/ecommerce-worker.git --branch {{ OPENEDX_COMMON_VERSION }} --depth 1 /openedx/ecommerce_worker
 WORKDIR /openedx/ecommerce_worker
 
 # Install python venv

--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -10,7 +10,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ###### Checkout code
 FROM minimal as checkout
 
-ARG ECOMMERCE_REPOSITORY=https://github.com/edx/ecommerce.git
+ARG ECOMMERCE_REPOSITORY=https://github.com/openedx/ecommerce.git
 ARG ECOMMERCE_VERSION='{{ OPENEDX_COMMON_VERSION }}'
 RUN mkdir -p /openedx/ecommerce && \
     git clone $ECOMMERCE_REPOSITORY --branch $ECOMMERCE_VERSION --depth 1 /openedx/ecommerce


### PR DESCRIPTION
2U is not currently forking ecommerce/ecommerce-worker back to the edX github org, but I wanted to make this change now as to not forget later should the a fork be made.