### PR TITLE
feat: change image CMD to celery v5 compatibility in ecom worker

### DIFF
--- a/tutorecommerce/templates/ecommerce/build/ecommerce-worker/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce-worker/Dockerfile
@@ -26,4 +26,4 @@ RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared pip install \
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared pip install -r requirements/production.txt
 
 ENV WORKER_CONFIGURATION_MODULE ecommerce_worker.settings.production
-CMD celery worker --app=ecommerce_worker.celery_app:app --loglevel=info  --maxtasksperchild 100 --queue=fulfillment,email_marketing
+CMD celery --app=ecommerce_worker.celery_app:app worker  --loglevel=info  --max-tasks-per-child 100 --queues=fulfillment,email_marketing


### PR DESCRIPTION
# Description

This is a proposal in order to allow ecommerce-worker increase celery to v5.4.0

This upgrade of celery is in the following PR: https://github.com/openedx/ecommerce-worker/pull/247

## Before
I tried to use the update code related in celery and I found some incompatibilities.
For more details you could check the following PR:
https://github.com/openedx/ecommerce-worker/pull/247#issuecomment-2083838629
V5.4.0 the celery command doesn't start. 
![image](https://github.com/overhangio/tutor-ecommerce/assets/51926076/e3afc9f2-37d0-4254-9ca6-24a50c4dc347)
![image](https://github.com/overhangio/tutor-ecommerce/assets/51926076/fbae42c3-b112-4fcc-a8c6-76e73639f767)

![image](https://github.com/overhangio/tutor-ecommerce/assets/51926076/8593cf7f-acc0-4c12-8862-10d1a0f7277b)

## After

Celery worker in V5.4.0 Seems working
![2024-04-29_17-58](https://github.com/overhangio/tutor-ecommerce/assets/51926076/37fd1615-9bae-4355-bc99-0b28c221e256)

![2024-04-29_17-57](https://github.com/overhangio/tutor-ecommerce/assets/51926076/450f650b-e4c4-4980-a83d-be516a6f4eb4)

 I  also test the args change with celery v4.4.7 but I prefer that this be tested with care.
![2024-04-29_17-55](https://github.com/overhangio/tutor-ecommerce/assets/51926076/7ac6ddd9-fbce-4af3-8923-acc6868e6e40)

This to think when this PR would be merged: before or after https://github.com/openedx/ecommerce-worker/pull/247
