### PR TITLE
docs: an honest deprecation warning for ecommerce service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ This is a plugin for `Tutor <https://docs.tutor.edly.io>`_ that integrates the `
 ⛔️ WARNING
 ==========
 
-This service is under-maintained. We are not fixing bugs or developing new features for it. We hope to deprecate and replace it soon. For updates, `follow along on the DEPR ticket <https://github.com/openedx/public-engineering/issues/22>`_.
+e-commerce and e-commerce worker are under-maintained. The Open edX community is not fixing bugs or developing new features for it. We hope to deprecate and replace it soon. For updates, `follow along on the DEPR ticket <https://github.com/openedx/public-engineering/issues/22>`_.
 
 Installation
 ------------

--- a/README.rst
+++ b/README.rst
@@ -3,6 +3,11 @@ E-Commerce plugin for `Tutor <https://docs.tutor.edly.io>`_
 
 This is a plugin for `Tutor <https://docs.tutor.edly.io>`_ that integrates the `E-Commerce <https://github.com/openedx/ecommerce/>`__ application in an Open edX platform.
 
+⛔️ WARNING
+==========
+
+This service is under-maintained. We are not fixing bugs or developing new features for it. We hope to deprecate and replace it soon. For updates, `follow along on the DEPR ticket <https://github.com/openedx/public-engineering/issues/22>`_.
+
 Installation
 ------------
 


### PR DESCRIPTION
Add the warning on the ecommerce repo to the Tutor plugin - see https://github.com/openedx/ecommerce?tab=readme-ov-file#%EF%B8%8F-warning

Partially addresses https://github.com/openedx/docs.openedx.org/issues/525 - see that ticket for more detail/discussion.