### PR TITLE
fix: Updating the uwsgi version to the latest

### DIFF
--- a/changelog.d/20241024_172729_faraz.maqsood_uwsgi_error_while_loading_shared_libraries.md
+++ b/changelog.d/20241024_172729_faraz.maqsood_uwsgi_error_while_loading_shared_libraries.md
@@ -1,0 +1,1 @@
+- [BugFix] Updating the uwsgi version to the latest fixes `uwsgi: error while loading shared libraries: libpython3.12.so.1.0: cannot open shared object file: No such file or directory`. (by @Faraz32123)

--- a/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
+++ b/tutorecommerce/templates/ecommerce/build/ecommerce/Dockerfile
@@ -82,7 +82,7 @@ RUN --mount=type=cache,target=/openedx/.cache/bower,sharing=shared,uid=${APP_USE
 # python requirements
 RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared,uid=${APP_USER_ID} pip install -r requirements.txt
 # https://pypi.org/project/uWSGI/
-RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared,uid=${APP_USER_ID} pip install uwsgi==2.0.24
+RUN --mount=type=cache,target=/openedx/.cache/pip,sharing=shared,uid=${APP_USER_ID} pip install uwsgi==2.0.27
 
 # Install private requirements: this is useful for installing custom payment processors.
 COPY --chown=app:app ./requirements/ /openedx/requirements


### PR DESCRIPTION
It fixes below error when the e-commerce container is Up and it keep restarting:
`uwsgi: error while loading shared libraries: libpython3.12.so.1.0: cannot open shared object file: No such file or directory`